### PR TITLE
Election record tweaks

### DIFF
--- a/docs/CommandLineInterface.md
+++ b/docs/CommandLineInterface.md
@@ -1,9 +1,9 @@
 # EGK Workflow and Command Line Programs
 
-last update 03/08/2024
+last update 03/11/2024
 
 <!-- TOC -->
-* [Workflow and Command Line Programs](#workflow-and-command-line-programs)
+* [EGK Workflow and Command Line Programs](#egk-workflow-and-command-line-programs)
   * [Election workflow overview](#election-workflow-overview)
   * [Make ekglib uberJar](#make-ekglib-uberjar)
   * [Create a fake Election Manifest](#create-a-fake-election-manifest)
@@ -298,6 +298,7 @@ Options:
     --outputDir, -out -> Directory to write output election record (always required) { String }
     --encryptDir, -eballots -> Read encrypted ballots here (optional) { String }
     --name, -name -> Name of tally { String }
+    --countNumberOfBallots, -count [false] -> count number of ballots for each contest 
     --createdBy, -createdBy -> who created { String }
     --help, -h -> Usage info 
 ````
@@ -331,6 +332,7 @@ Options:
     --inputDir, -in -> Directory containing input election record (always required) { String }
     --trusteeDir, -trustees -> Directory to read private trustees (always required) { String }
     --outputDir, -out -> Directory to write output election record (always required) { String }
+    --encryptedTallyFile, -encryptedTally -> encryptedTally file (if different from the one in the election record) { String }
     --createdBy, -createdBy -> who created { String }
     --missing, -missing -> missing guardians' xcoord, comma separated, eg '2,4' { String }
     --help, -h -> Usage info 

--- a/docs/JsonSerializationSpec2.1.md
+++ b/docs/JsonSerializationSpec2.1.md
@@ -1,6 +1,6 @@
 # Egk Election Record JSON 2.1 serialization (proposed specification)
 
-draft 03/10/2024
+draft 03/11/2024
 
 ### Constants
 
@@ -528,6 +528,7 @@ data class EncryptedTallyContestJson(
     val contest_id: String,
     val sequence_order: Int,
     val selections: List<EncryptedTallySelectionJson>,
+    val ballot_count: Int,                     // number of ballots voting on this contest
 )
 
 @Serializable
@@ -618,6 +619,7 @@ data class DecryptedTallyOrBallotJson(
 data class DecryptedContestJson(
     val contest_id: String,
     val selections: List<DecryptedSelectionJson>,
+    val ballot_count: Int,                     // number of ballots voting on this contest
     val decrypted_contest_data: DecryptedContestDataJson?, //  ballot decryption only
 )
 

--- a/src/main/kotlin/org/cryptobiotic/eg/cli/RunAccumulateTally.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/cli/RunAccumulateTally.kt
@@ -12,6 +12,7 @@ import org.cryptobiotic.util.ErrorMessages
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
+import kotlinx.cli.default
 import kotlinx.cli.required
 import org.cryptobiotic.util.Stopwatch
 
@@ -47,6 +48,11 @@ class RunAccumulateTally {
                 shortName = "name",
                 description = "Name of tally"
             )
+            val countNumberOfBallots by parser.option(
+                ArgType.Boolean,
+                shortName = "count",
+                description = "count number of ballots for each contest"
+            ).default(false)
             val createdBy by parser.option(
                 ArgType.String,
                 shortName = "createdBy",
@@ -54,10 +60,11 @@ class RunAccumulateTally {
             )
             parser.parse(args)
 
-            val startupInfo = "starting" +
+            val startupInfo = "starting '$name" +
                     "\n   input= $inputDir" +
                     "\n   outputDir = $outputDir" +
-                    "\n   encryptDir = $encryptDir"
+                    "\n   encryptDir = $encryptDir" +
+                    "\n   countNumberOfBallots = $countNumberOfBallots"
             logger.info { startupInfo }
 
             try {
@@ -66,7 +73,8 @@ class RunAccumulateTally {
                     outputDir,
                     encryptDir,
                     name ?: "RunAccumulateTally",
-                    createdBy ?: "RunAccumulateTally"
+                    createdBy ?: "RunAccumulateTally",
+                    countNumberOfBallots,
                 )
                 logger.info {"success"}
 
@@ -81,7 +89,8 @@ class RunAccumulateTally {
             outputDir: String,
             encryptDir: String?,
             name: String,
-            createdBy: String
+            createdBy: String,
+            countNumberOfBallots: Boolean = false,
         ) {
             val stopwatch = Stopwatch()
 
@@ -97,7 +106,7 @@ class RunAccumulateTally {
 
             var countBad = 0
             var countOk = 0
-            val accumulator = AccumulateTally(group, manifest, name, electionInit.extendedBaseHash, electionInit.jointPublicKey())
+            val accumulator = AccumulateTally(group, manifest, name, electionInit.extendedBaseHash, electionInit.jointPublicKey(), countNumberOfBallots)
             val encryptedBallots = if (encryptDir == null) consumerIn.iterateAllCastBallots()
                                    else consumerIn.iterateEncryptedBallotsFromDir(encryptDir, null, null)
             for (encryptedBallot in encryptedBallots) {

--- a/src/main/kotlin/org/cryptobiotic/eg/decrypt/Decryptor.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/decrypt/Decryptor.kt
@@ -303,6 +303,7 @@ fun EncryptedBallot.convertToTally(): EncryptedTally {
             contest.contestId,
             contest.sequenceOrder,
             selections,
+            1,
             contest.contestData,
         )
     }

--- a/src/main/kotlin/org/cryptobiotic/eg/decrypt/TallyDecryptor.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/decrypt/TallyDecryptor.kt
@@ -46,7 +46,8 @@ internal class TallyDecryptor(
                 errs.addNull("'$id' share not found") as DecryptedTallyOrBallot.Selection?
             else decryptSelection(it, shares, contest.contestId, stats, errs.nested("Selection ${it.selectionId}"))
         }
-        return if (errs.hasErrors()) null else DecryptedTallyOrBallot.Contest(contest.contestId, selections.filterNotNull(), decryptedContestData)
+        return if (errs.hasErrors()) null
+               else DecryptedTallyOrBallot.Contest(contest.contestId, selections.filterNotNull(), contest.ballot_count, decryptedContestData)
     }
 
     private fun decryptContestData(

--- a/src/main/kotlin/org/cryptobiotic/eg/election/DecryptedTallyOrBallot.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/election/DecryptedTallyOrBallot.kt
@@ -19,6 +19,7 @@ data class DecryptedTallyOrBallot(
     data class Contest(
         val contestId: String, // matches ContestDescription.contestId
         val selections: List<Selection>,
+        val ballot_count: Int = 0,                 // number of ballots voting on this contest
         val decryptedContestData: DecryptedContestData? = null, // only for ballots
     ) {
         init {

--- a/src/main/kotlin/org/cryptobiotic/eg/election/EncryptedTally.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/election/EncryptedTally.kt
@@ -17,6 +17,7 @@ data class EncryptedTally(
         val contestId: String,              // matches ContestDescription.contestId
         val sequenceOrder: Int,             // matches ContestDescription.sequenceOrder
         val selections: List<Selection>,
+        val ballot_count: Int = 0,          // number of ballots voting on this contest
         val contestData: HashedElGamalCiphertext? = null, // only used when decrypting ballots, not tallies
     ) {
         init {

--- a/src/main/kotlin/org/cryptobiotic/eg/election/Manifest.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/election/Manifest.kt
@@ -1,7 +1,7 @@
 package org.cryptobiotic.eg.election
 
 /** The ElectionGuard Manifest: defines the candidates, contests, and associated information for a specific election. */
-data class Manifest(
+class Manifest(
     val electionScopeId: String,
     val specVersion: String,
     val electionType: ElectionType,
@@ -10,11 +10,12 @@ data class Manifest(
     val geopoliticalUnits: List<GeopoliticalUnit>,
     val parties: List<Party>,
     val candidates: List<Candidate>,
-    override val contests: List<ContestDescription>,
+    contestsInput: List<ContestDescription>,
     val ballotStyles: List<BallotStyle>,
     val name: List<Language>,
     val contactInformation: ContactInformation?,
 ) : ManifestIF {
+    override val contests: List<ContestDescription> = contestsInput.sortedBy { it.sequenceOrder }
 
     /** Map of ballotStyleId to all Contests that use it. */
     val styleToContestsMap = mutableMapOf<String, List<ContestDescription>>() // key = ballotStyleId
@@ -48,6 +49,44 @@ data class Manifest(
         return contestMap[contestId]?.optionSelectionLimit ?: 1
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Manifest) return false
+
+        if (electionScopeId != other.electionScopeId) return false
+        if (specVersion != other.specVersion) return false
+        if (electionType != other.electionType) return false
+        if (startDate != other.startDate) return false
+        if (endDate != other.endDate) return false
+        if (geopoliticalUnits != other.geopoliticalUnits) return false
+        if (parties != other.parties) return false
+        if (candidates != other.candidates) return false
+        if (ballotStyles != other.ballotStyles) return false
+        if (name != other.name) return false
+        if (contactInformation != other.contactInformation) return false
+        if (contests != other.contests) return false
+        if (styleToContestsMap != other.styleToContestsMap) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = electionScopeId.hashCode()
+        result = 31 * result + specVersion.hashCode()
+        result = 31 * result + electionType.hashCode()
+        result = 31 * result + startDate.hashCode()
+        result = 31 * result + endDate.hashCode()
+        result = 31 * result + geopoliticalUnits.hashCode()
+        result = 31 * result + parties.hashCode()
+        result = 31 * result + candidates.hashCode()
+        result = 31 * result + ballotStyles.hashCode()
+        result = 31 * result + name.hashCode()
+        result = 31 * result + (contactInformation?.hashCode() ?: 0)
+        result = 31 * result + contests.hashCode()
+        result = 31 * result + styleToContestsMap.hashCode()
+        return result
+    }
+
     /** Map of contestId to contests. */
     val contestMap : Map<String, ContestDescription> by
     lazy {
@@ -64,7 +103,7 @@ data class Manifest(
      * The structure and type of one contest in the election.
      * @see [Civics Common Standard Data Specification](https://developers.google.com/elections-data/reference/contest)
      */
-    data class ContestDescription(
+    class ContestDescription(
         override val contestId: String,
         override val sequenceOrder: Int,
         val geopoliticalUnitId: String,
@@ -72,11 +111,47 @@ data class Manifest(
         val numberElected: Int,
         val contestSelectionLimit: Int, // contest selection limit = L, spec 2.0 p 17.
         val name: String,
-        override val selections: List<SelectionDescription>,
+        selectionsInput: List<SelectionDescription>,
         val ballotTitle: String?,
         val ballotSubtitle: String?,
         val optionSelectionLimit: Int = 1, // option selection limit = R, spec 2.0 p 17.
-    ) : ManifestIF.Contest
+    ) : ManifestIF.Contest {
+        override val selections: List<SelectionDescription> = selectionsInput.sortedBy { it.sequenceOrder }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is ContestDescription) return false
+
+            if (contestId != other.contestId) return false
+            if (sequenceOrder != other.sequenceOrder) return false
+            if (geopoliticalUnitId != other.geopoliticalUnitId) return false
+            if (voteVariation != other.voteVariation) return false
+            if (numberElected != other.numberElected) return false
+            if (contestSelectionLimit != other.contestSelectionLimit) return false
+            if (name != other.name) return false
+            if (ballotTitle != other.ballotTitle) return false
+            if (ballotSubtitle != other.ballotSubtitle) return false
+            if (optionSelectionLimit != other.optionSelectionLimit) return false
+            if (selections != other.selections) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = contestId.hashCode()
+            result = 31 * result + sequenceOrder
+            result = 31 * result + geopoliticalUnitId.hashCode()
+            result = 31 * result + voteVariation.hashCode()
+            result = 31 * result + numberElected
+            result = 31 * result + contestSelectionLimit
+            result = 31 * result + name.hashCode()
+            result = 31 * result + (ballotTitle?.hashCode() ?: 0)
+            result = 31 * result + (ballotSubtitle?.hashCode() ?: 0)
+            result = 31 * result + optionSelectionLimit
+            result = 31 * result + selections.hashCode()
+            return result
+        }
+    }
 
     /**
      * A ballot selection for a specific candidate in a contest.
@@ -387,4 +462,6 @@ data class Manifest(
     ) {
         constructor(partyId: String) : this(partyId,"",null, null, null)
     }
+
+
 }

--- a/src/main/kotlin/org/cryptobiotic/eg/election/ManifestIF.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/election/ManifestIF.kt
@@ -2,12 +2,12 @@ package org.cryptobiotic.eg.election
 
 /** Interface used in the crypto routines for easy mocking. */
 interface ManifestIF {
-    val contests: List<Contest>
+    val contests: List<Contest> // in order by sequence number
 
     interface Contest {
         val contestId: String
         val sequenceOrder: Int
-        val selections: List<Selection>
+        val selections: List<Selection> // in order by sequence number
     }
 
     interface Selection {
@@ -25,5 +25,4 @@ interface ManifestIF {
 
     /** get the option selection limit for the given contest id */
     fun optionLimit(contestId : String): Int
-
 }

--- a/src/main/kotlin/org/cryptobiotic/eg/encrypt/Encryptor.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/encrypt/Encryptor.kt
@@ -44,7 +44,7 @@ class Encryptor(
             return null
         }
         for (mcontest in manifestContests) {
-            // If no contest on the ballot, create a well formed contest with all zeroes
+            // If no contest on the pballot, create a well formed contest with all zeroes
             val pcontest = plaintextContests[mcontest.contestId] ?: makeZeroContest(mcontest)
             encryptedContests.add(
                 pcontest.encryptContest(mcontest,

--- a/src/main/kotlin/org/cryptobiotic/eg/publish/Consumer.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/publish/Consumer.kt
@@ -29,7 +29,9 @@ interface Consumer {
     fun readElectionConfig(): Result<ElectionConfig, ErrorMessages>
     fun readElectionInitialized(): Result<ElectionInitialized, ErrorMessages>
     fun readTallyResult(): Result<TallyResult, ErrorMessages>
+    fun readEncryptedTallyFromFile(filename: String): Result<EncryptedTally, ErrorMessages>
     fun readDecryptionResult(): Result<DecryptionResult, ErrorMessages>
+    fun readDecryptedTallyFromFile(filename: String): Result<DecryptedTallyOrBallot, ErrorMessages>
 
     /** Are there any encrypted ballots? */
     fun hasEncryptedBallots() : Boolean

--- a/src/main/kotlin/org/cryptobiotic/eg/publish/Publisher.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/publish/Publisher.kt
@@ -13,8 +13,9 @@ interface Publisher {
     fun writeManifest(manifest: Manifest) : String // return filename
     fun writeElectionConfig(config: ElectionConfig)
     fun writeElectionInitialized(init: ElectionInitialized)
-    fun writeTallyResult(tally: TallyResult)
+    fun writeTallyResult(tally: TallyResult, complete: Boolean = true)
     fun writeDecryptionResult(decryption: DecryptionResult)
+    fun writeDecryptedTally(decryption: DecryptedTallyOrBallot)
 
     fun encryptedBallotSink(device: String?, batched : Boolean = false): EncryptedBallotSinkIF
     fun writeEncryptedBallotChain(closing: EncryptedBallotChain, ballotOverrideDir: String? = null)

--- a/src/main/kotlin/org/cryptobiotic/eg/publish/json/DecryptedTallyOrBallotJson.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/publish/json/DecryptedTallyOrBallotJson.kt
@@ -16,6 +16,7 @@ data class DecryptedTallyOrBallotJson(
 data class DecryptedContestJson(
     val contest_id: String,
     val selections: List<DecryptedSelectionJson>,
+    val ballot_count: Int = 0,                 // number of ballots voting on this contest
     val decrypted_contest_data: DecryptedContestDataJson?, //  ballot decryption only
 )
 
@@ -42,6 +43,7 @@ fun DecryptedTallyOrBallot.publishJson() = DecryptedTallyOrBallotJson(
                     selection.proof.publishJson(),
                 )
             },
+            contest.ballot_count,
             contest.decryptedContestData?.publishJson(),
         )
     },
@@ -71,6 +73,7 @@ fun DecryptedContestJson.import(group: GroupContext, errs: ErrorMessages): Decry
     else DecryptedTallyOrBallot.Contest(
             this.contest_id,
             selections.filterNotNull(),
+            this.ballot_count,
             decryptedContestData,
         )
 }

--- a/src/main/kotlin/org/cryptobiotic/eg/publish/json/EncryptedTallyJson.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/publish/json/EncryptedTallyJson.kt
@@ -18,6 +18,7 @@ data class EncryptedTallyContestJson(
     val contest_id: String,
     val sequence_order: Int,
     val selections: List<EncryptedTallySelectionJson>,
+    val ballot_count: Int = 0,                 // number of ballots voting on this contest
 )
 
 @Serializable
@@ -39,7 +40,9 @@ fun EncryptedTally.publishJson(): EncryptedTallyJson {
                     it.sequenceOrder,
                     it.encryptedVote.publishJson(),
                 )
-            })
+            },
+            pcontest.ballot_count,
+        )
     }
     return EncryptedTallyJson(
         this.tallyId,
@@ -56,7 +59,7 @@ fun EncryptedTallyJson.import(group: GroupContext, errs : ErrorMessages): Encryp
     val electionId = this.election_id.import() ?: errs.addNull("EncryptedTally malformed election_id") as UInt256?
 
     return if (errs.hasErrors()) null
-    else  EncryptedTally(
+    else EncryptedTally(
         this.tally_id,
         contests.filterNotNull(),
         this.cast_ballot_ids,
@@ -71,7 +74,8 @@ fun EncryptedTallyContestJson.import(group: GroupContext, errs : ErrorMessages):
     else EncryptedTally.Contest(
         this.contest_id,
         this.sequence_order,
-        selections.filterNotNull()
+        selections.filterNotNull(),
+        this.ballot_count,
     )
 }
 

--- a/src/main/kotlin/org/cryptobiotic/eg/publish/json/PublisherJson.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/publish/json/PublisherJson.kt
@@ -71,8 +71,8 @@ class PublisherJson(topDir: String, createNew: Boolean) : Publisher {
         }
     }
 
-    override fun writeTallyResult(tally: TallyResult) {
-        writeElectionInitialized(tally.electionInitialized)
+    override fun writeTallyResult(tally: TallyResult, complete: Boolean) {
+        if (complete) writeElectionInitialized(tally.electionInitialized)
 
         val encryptedTallyJson = tally.encryptedTally.publishJson()
         FileOutputStream(jsonPaths.encryptedTallyPath()).use { out ->
@@ -83,8 +83,11 @@ class PublisherJson(topDir: String, createNew: Boolean) : Publisher {
 
     override fun writeDecryptionResult(decryption: DecryptionResult) {
         writeTallyResult(decryption.tallyResult)
+        writeDecryptedTally(decryption.decryptedTally)
+    }
 
-        val decryptedTallyJson = decryption.decryptedTally.publishJson()
+    override fun writeDecryptedTally(decryption: DecryptedTallyOrBallot) {
+        val decryptedTallyJson = decryption.publishJson()
         FileOutputStream(jsonPaths.decryptedTallyPath()).use { out ->
             jsonReader.encodeToStream(decryptedTallyJson, out)
             out.close()

--- a/src/test/kotlin/org/cryptobiotic/eg/decrypt/RunTrustedTallyDecryptionTest.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/decrypt/RunTrustedTallyDecryptionTest.kt
@@ -41,4 +41,19 @@ class RunTrustedTallyDecryptionTest {
             )
         )
     }
+
+
+    @Test
+    fun testDecryptionFromFile() {
+        RunTrustedTallyDecryption.main(
+            arrayOf(
+                "-in", "src/test/data/workflow/someAvailableEc",
+                "-trustees", "src/test/data/workflow/someAvailableEc/private_data/trustees",
+                "-out", "$testOut/decrypt/testDecryptionFromFile",
+                "--encryptedTallyFile", "src/test/data/workflow/someAvailableEc/encrypted_tally.json",
+                "-createdBy", "testDecryptionFromFile",
+                "-missing", "1,4"
+            )
+        )
+    }
 }

--- a/src/test/kotlin/org/cryptobiotic/eg/encrypt/AddBallotSyncTest.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/encrypt/AddBallotSyncTest.kt
@@ -1,6 +1,7 @@
 package org.cryptobiotic.eg.encrypt
 
 import org.cryptobiotic.eg.election.*
+import org.cryptobiotic.eg.input.BallotInputValidation
 import org.cryptobiotic.eg.input.RandomBallotProvider
 import org.cryptobiotic.eg.publish.makePublisher
 import org.cryptobiotic.eg.publish.readElectionRecord
@@ -22,9 +23,11 @@ class AddBallotSyncTest {
         val electionInit = electionRecord.electionInit()!!
         val publisher = makePublisher(outputDir, true)
         publisher.writeElectionInitialized(electionInit)
+        val manifest = electionRecord.manifest()
 
         val encryptor = AddEncryptedBallot(
-            electionRecord.manifest(),
+            manifest,
+            BallotInputValidation(manifest),
             electionInit.config.chainConfirmationCodes,
             electionInit.config.configBaux0,
             electionInit.jointPublicKey(),
@@ -65,12 +68,14 @@ class AddBallotSyncTest {
         val electionRecord = readElectionRecord(inputJson)
         val configWithChaining = electionRecord.config().copy(chainConfirmationCodes = true)
         val electionInit = electionRecord.electionInit()!!.copy(config = configWithChaining)
+        val manifest = electionRecord.manifest()
 
         val publisher = makePublisher(outputDir, true)
         publisher.writeElectionInitialized(electionInit)
 
         val addEncryptor = AddEncryptedBallot(
-            electionRecord.manifest(),
+            manifest,
+            BallotInputValidation(manifest),
             electionInit.config.chainConfirmationCodes,
             electionInit.config.configBaux0,
             electionInit.jointPublicKey(),

--- a/src/test/kotlin/org/cryptobiotic/eg/encrypt/AddEncryptedBallotTest.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/encrypt/AddEncryptedBallotTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.*
 
 import org.cryptobiotic.eg.core.*
 import org.cryptobiotic.eg.election.*
+import org.cryptobiotic.eg.input.BallotInputValidation
 import org.cryptobiotic.eg.input.RandomBallotProvider
 import org.cryptobiotic.eg.publish.makeConsumer
 import org.cryptobiotic.eg.publish.makePublisher
@@ -32,6 +33,7 @@ class AddEncryptedBallotTest {
 
         val encryptor = AddEncryptedBallot(
             electionRecord.manifest(),
+            BallotInputValidation(electionRecord.manifest()),
             electionInit.config.chainConfirmationCodes,
             electionInit.config.configBaux0,
             electionInit.jointPublicKey(),
@@ -66,6 +68,7 @@ class AddEncryptedBallotTest {
 
         val encryptor = AddEncryptedBallot(
             electionRecord.manifest(),
+            BallotInputValidation(electionRecord.manifest()),
             electionInit.config.chainConfirmationCodes,
             electionInit.config.configBaux0,
             electionInit.jointPublicKey(),
@@ -100,6 +103,7 @@ class AddEncryptedBallotTest {
 
         val encryptor = AddEncryptedBallot(
             electionRecord.manifest(),
+            BallotInputValidation(electionRecord.manifest()),
             electionInit.config.chainConfirmationCodes,
             electionInit.config.configBaux0,
             electionInit.jointPublicKey(),
@@ -135,6 +139,7 @@ class AddEncryptedBallotTest {
         repeat(3) {
             val encryptor = AddEncryptedBallot(
                 electionRecord.manifest(),
+                BallotInputValidation(electionRecord.manifest()),
                 electionInit.config.chainConfirmationCodes,
                 electionInit.config.configBaux0,
                 electionInit.jointPublicKey(),
@@ -170,6 +175,7 @@ class AddEncryptedBallotTest {
         repeat(3) { it ->
             val encryptor = AddEncryptedBallot(
                 electionRecord.manifest(),
+                BallotInputValidation(electionRecord.manifest()),
                 electionInit.config.chainConfirmationCodes,
                 electionInit.config.configBaux0,
                 electionInit.jointPublicKey(),
@@ -207,6 +213,7 @@ class AddEncryptedBallotTest {
 
         val encryptor = AddEncryptedBallot(
             electionRecord.manifest(),
+            BallotInputValidation(electionRecord.manifest()),
             electionInit.config.chainConfirmationCodes,
             electionInit.config.configBaux0,
             electionInit.jointPublicKey(),
@@ -244,6 +251,7 @@ class AddEncryptedBallotTest {
         repeat(4) {
             val encryptor = AddEncryptedBallot(
                 electionRecord.manifest(),
+                BallotInputValidation(electionRecord.manifest()),
                 electionInit.config.chainConfirmationCodes,
                 electionInit.config.configBaux0,
                 electionInit.jointPublicKey(),
@@ -281,6 +289,7 @@ class AddEncryptedBallotTest {
         repeat(3) {
             val encryptor = AddEncryptedBallot(
                 electionRecord.manifest(),
+                BallotInputValidation(electionRecord.manifest()),
                 electionInit.config.chainConfirmationCodes,
                 electionInit.config.configBaux0,
                 electionInit.jointPublicKey(),

--- a/src/test/kotlin/org/cryptobiotic/eg/encrypt/AddEncryptedUnorderedTest.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/encrypt/AddEncryptedUnorderedTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertNotNull
 
 import org.cryptobiotic.eg.election.*
+import org.cryptobiotic.eg.input.BallotInputValidation
 import org.cryptobiotic.eg.input.RandomBallotProvider
 import org.cryptobiotic.eg.publish.makePublisher
 import org.cryptobiotic.eg.publish.readElectionRecord
@@ -30,6 +31,7 @@ class AddEncryptedUnorderedTest {
 
         val encryptor = AddEncryptedBallot(
             electionRecord.manifest(),
+            BallotInputValidation(electionRecord.manifest()),
             electionInit.config.chainConfirmationCodes,
             electionInit.config.configBaux0,
             electionInit.jointPublicKey(),
@@ -67,6 +69,7 @@ class AddEncryptedUnorderedTest {
         repeat(3) { it ->
             val encryptor = AddEncryptedBallot(
                 electionRecord.manifest(),
+                BallotInputValidation(electionRecord.manifest()),
                 electionInit.config.chainConfirmationCodes,
                 electionInit.config.configBaux0,
                 electionInit.jointPublicKey(),
@@ -107,6 +110,7 @@ class AddEncryptedUnorderedTest {
 
         val encryptor = AddEncryptedBallot(
             electionRecord.manifest(),
+            BallotInputValidation(electionRecord.manifest()),
             electionInit.config.chainConfirmationCodes,
             electionInit.config.configBaux0,
             electionInit.jointPublicKey(),
@@ -146,6 +150,7 @@ class AddEncryptedUnorderedTest {
         repeat(3) { it ->
             val encryptor = AddEncryptedBallot(
                 electionRecord.manifest(),
+                BallotInputValidation(electionRecord.manifest()),
                 electionInit.config.chainConfirmationCodes,
                 electionInit.config.configBaux0,
                 electionInit.jointPublicKey(),
@@ -209,6 +214,7 @@ class AddEncryptedUnorderedTest {
             repeat(3) {
                 val encryptor = AddEncryptedBallot(
                     electionRecord.manifest(),
+                    BallotInputValidation(electionRecord.manifest()),
                     electionInit.config.chainConfirmationCodes,
                     electionInit.config.configBaux0,
                     electionInit.jointPublicKey(),

--- a/src/test/kotlin/org/cryptobiotic/eg/input/KotestBallotGenerators.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/input/KotestBallotGenerators.kt
@@ -397,7 +397,7 @@ object KotestBallotGenerators {
             numberElected = n,
             contestSelectionLimit = n,
             name = "Contest $sequenceOrder",
-            selections = selectionDescriptions,
+            selectionsInput = selectionDescriptions,
             ballotTitle =  "Title $sequenceOrder",
             ballotSubtitle = "Subtitle $sequenceOrder",
         ))
@@ -432,7 +432,7 @@ object KotestBallotGenerators {
             geopoliticalUnits = geoUnits,
             parties = parties,
             candidates = candidates,
-            contests = contests,
+            contestsInput = contests,
             ballotStyles = listOf(styles),
             name = listOf(language("Manifest: ").bind()),
             contactInformation = contactInformation().bind()


### PR DESCRIPTION
Manifest tweaks.
Pass ManifestIF, BallotInputValidation into the Encryptor. 
Manifest contests, selections are always sorted.
Add optional ballot count to EncryptedTally.Contest, DecryptedTallyOrBallot.Contest. 
Add optional encryptedTallyFile to RunTrustedTallyDecryption to decrypt different tally.