### PR TITLE
Tweak encrypted ballot read/writing API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ElectionGuard-Kotlin Elliptic Curve
 
-_last update 03/18/2024_
+_last update 04/07/2024_
 
 EGK Elliptic Curve (egk-ec) is an experimental implementation of [ElectionGuard](https://github.com/microsoft/electionguard), 
 [version 2.0](https://github.com/microsoft/electionguard/releases/download/v2.0/EG_Spec_2_0.pdf), 
@@ -20,6 +20,8 @@ This library also can use the Electionguard Integer Group, and so can also be us
 See [EGK EC mixnet](https://github.com/JohnLCaron/egk-ec-mixnet) for an implementation of a mixnet using this library with Elliptic Curves.
 
 See [EGK webapps](https://github.com/JohnLCaron/egk-webapps) for HTTP client/server applications that use this library to allow remote workflows.
+
+Currently we have 88.5% (6854/7745) LOC test coverage.
 
 ## Documentation
 * [Getting Started](docs/GettingStarted.md)

--- a/docs/CommandLineInterface.md
+++ b/docs/CommandLineInterface.md
@@ -203,7 +203,7 @@ Usage: RunEncryptBallot options_list
 Options: 
     --inputDir, -in -> Directory containing input election record (always required) { String }
     --device, -device -> voting device name (always required) { String }
-    --ballotFilename, -ballot -> Plaintext ballot filename (or 'CLOSE') (always required) { String }
+    --ballotFilepath, -ballot -> Plaintext ballot filepath (or 'CLOSE') (always required) { String }
     --encryptBallotDir, -output -> Write encrypted ballot to this directory (always required) { String }
     --help, -h -> Usage info     
 ````
@@ -213,8 +213,8 @@ The standard place to write encrypted ballots is to _workingDir/encrypted_ballot
 named _eballot-ballotId.json_, where _ballotId_ is taken from the plaintext ballot.
 
 If the config file has chainConfirmationCodes = true, then RunEncryptBallot will expect to be able to read
-and write _ballot_chain.json_ in the _encryptBallotDir/device_ directory. The ballot chaining should be closed by sending 
-ballotFilename = "Close" when the chain is complete. The directory name should have the device name in it as per the example.
+and write _ballot_chain.json_ in the _encryptBallotDir_ directory. The ballot chaining should be closed by sending 
+ballotFilename = "Close" when the chain is complete.
 
 Example:
 

--- a/src/main/kotlin/org/cryptobiotic/eg/cli/RunEncryptBallot.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/cli/RunEncryptBallot.kt
@@ -45,10 +45,10 @@ class RunEncryptBallot {
                 shortName = "device",
                 description = "voting device name"
             ).required()
-            val ballotFilename by parser.option(
+            val ballotFilepath by parser.option(
                 ArgType.String,
                 shortName = "ballot",
-                description = "Plaintext ballot filename (or 'CLOSE')"
+                description = "Plaintext ballot filepath (or 'CLOSE')"
             ).required()
             val encryptBallotDir by parser.option(
                 ArgType.String,
@@ -58,17 +58,17 @@ class RunEncryptBallot {
             parser.parse(args)
 
             logger.info {
-                "starting\n inputDir= $inputDir\n ballotFilename= $ballotFilename\n encryptBallotDir = $encryptBallotDir\n device = $device"
+                "starting\n inputDir= $inputDir\n ballotFilepath= $ballotFilepath\n encryptBallotDir = $encryptBallotDir\n device = $device"
             }
 
             val consumerIn = makeConsumer(inputDir)
             try {
-                if (ballotFilename == "CLOSE") {
+                if (ballotFilepath == "CLOSE") {
                    close(consumerIn.group, device, encryptBallotDir)
                 } else {
                     val retval = encryptBallot(
                         consumerIn,
-                        ballotFilename,
+                        ballotFilepath,
                         encryptBallotDir,
                         device,
                     )
@@ -86,7 +86,7 @@ class RunEncryptBallot {
 
         fun encryptBallot(
             consumerIn: Consumer,
-            ballotFilename: String,
+            ballotFilepath: String,
             encryptBallotDir: String,
             device: String,
         ): Int {
@@ -111,7 +111,7 @@ class RunEncryptBallot {
                 device,
             )
 
-            val result = consumerIn.readPlaintextBallot(ballotFilename)
+            val result = consumerIn.readPlaintextBallot(ballotFilepath)
             if (result is Err) {
                 logger.error { "readPlaintextBallot $result" }
                 return 3
@@ -128,7 +128,7 @@ class RunEncryptBallot {
             } else {
                 val consumerChain = makeConsumer(encryptBallotDir, consumerIn.group)
                 // this will read in an existing chain, and so recover from machine going down.
-                val pair = makeCodeBaux(consumerChain, device, encryptBallotDir, configBaux0, electionInit.extendedBaseHash, )
+                val pair = makeCodeBaux(consumerChain, device, encryptBallotDir, configBaux0, electionInit.extendedBaseHash )
                 codeBaux = pair.first
                 currentChain = pair.second
             }
@@ -181,7 +181,7 @@ class RunEncryptBallot {
             val retval = if (chainResult is Ok) {
                 val chain = chainResult.unwrap()
                 val publisher = makePublisher(encryptBallotDir) // TODO not placing it into the device directory?
-                val termval = terminateChain(publisher, device, encryptBallotDir, chain,)
+                val termval = terminateChain(publisher, device, encryptBallotDir, chain)
                 if (termval != 0) {
                     logger.info { "Cant terminateBallotChain retval=$termval" }
                 }

--- a/src/main/kotlin/org/cryptobiotic/eg/encrypt/EncryptedBallotChain.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/encrypt/EncryptedBallotChain.kt
@@ -153,7 +153,7 @@ data class EncryptedBallotChain(
             }
 
             if (showChain) {
-                println("ballotChainNew")
+                println("assembleChain")
                 bauxMap.forEach { println("  $it") }
             }
 

--- a/src/main/kotlin/org/cryptobiotic/eg/publish/Consumer.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/publish/Consumer.kt
@@ -35,9 +35,9 @@ interface Consumer {
 
     /** Are there any encrypted ballots? */
     fun hasEncryptedBallots() : Boolean
-    /** Read a specific file containing an encrypted ballot. */
-    fun readEncryptedBallot(ballotDir: String, ballotId: String) : Result<EncryptedBallot, ErrorMessages>
-    /** Read all encrypted ballots for all devices. */
+    /** Find and read the encrypted ballot with the given ballotId. */
+    fun readEncryptedBallot(device: String?, ballotId: String) : Result<EncryptedBallot, ErrorMessages>
+    /** Read encrypted ballots for all devices. */
     fun iterateAllEncryptedBallots(filter : ((EncryptedBallot) -> Boolean)? ): Iterable<EncryptedBallot>
     fun iterateAllCastBallots(): Iterable<EncryptedBallot>  = iterateAllEncryptedBallots{  it.state == EncryptedBallot.BallotState.CAST }
     fun iterateAllChallengedBallots(): Iterable<EncryptedBallot>  = iterateAllEncryptedBallots{  it.state == EncryptedBallot.BallotState.CHALLENGED }
@@ -61,7 +61,7 @@ interface Consumer {
     /** read trustee in given directory for given guardianId, private data. */
     fun readTrustee(trusteeDir: String, guardianId: String): Result<DecryptingTrusteeIF, ErrorMessages>
     /** read plaintext ballot. */
-    fun readPlaintextBallot(ballotFilename: String): Result<PlaintextBallot, ErrorMessages>
+    fun readPlaintextBallot(ballotFilepath: String): Result<PlaintextBallot, ErrorMessages>
 }
 
 /**

--- a/src/main/kotlin/org/cryptobiotic/eg/publish/json/ConsumerJson.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/publish/json/ConsumerJson.kt
@@ -160,9 +160,9 @@ class ConsumerJson(val topDir: String, usegroup: GroupContext? = null) : Consume
         return iter.iterator().hasNext()
     }
 
-    override fun readEncryptedBallot(ballotDir: String, ballotId: String) : Result<EncryptedBallot, ErrorMessages> {
-        val errs = ErrorMessages("readEncryptedBallot ballotId=$ballotId from directory $ballotDir")
-        val ballotFilename = jsonPaths.encryptedBallotPath(ballotDir, ballotId)
+    override fun readEncryptedBallot(device: String?, ballotId: String) : Result<EncryptedBallot, ErrorMessages> {
+        val errs = ErrorMessages("readEncryptedBallot ballotId=$ballotId from device $device")
+        val ballotFilename = jsonPaths.encryptedBallotDevicePath(device, ballotId)
         if (!Files.exists(fileSystem.getPath(ballotFilename))) {
             return errs.add("'$ballotFilename' file does not exist")
         }
@@ -266,12 +266,12 @@ class ConsumerJson(val topDir: String, usegroup: GroupContext? = null) : Consume
     }
 
     // read the PlaintextBallot from the given filename
-    override fun readPlaintextBallot(ballotFilename: String): Result<PlaintextBallot, ErrorMessages> {
-        val errs = ErrorMessages("readPlaintextBallot $ballotFilename")
-        if (!Files.exists(fileSystem.getPath(ballotFilename))) {
+    override fun readPlaintextBallot(ballotFilepath: String): Result<PlaintextBallot, ErrorMessages> {
+        val errs = ErrorMessages("readPlaintextBallot $ballotFilepath")
+        if (!Files.exists(fileSystem.getPath(ballotFilepath))) {
             return errs.add("file does not exist ")
         }
-        val file = fileSystem.getPath(ballotFilename)
+        val file = fileSystem.getPath(ballotFilepath)
         return try {
             fileSystemProvider.newInputStream(file, StandardOpenOption.READ).use { inp ->
                 val json = jsonReader.decodeFromStream<PlaintextBallotJson>(inp)

--- a/src/main/kotlin/org/cryptobiotic/eg/publish/json/ElectionRecordJsonPaths.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/publish/json/ElectionRecordJsonPaths.kt
@@ -98,11 +98,6 @@ data class ElectionRecordJsonPaths(val topDir : String) {
         return "$ballotDir/$PLAINTEXT_BALLOT_PREFIX$id$JSON_SUFFIX"
     }
 
-    fun encryptedBallotPath(ballotDir : String, ballotId : String): String {
-        val id = ballotId.replace(" ", "_")
-        return "${ballotDir}/$ENCRYPTED_BALLOT_PREFIX$id$JSON_SUFFIX"
-    }
-
     fun decryptedBallotPath(ballotOverrideDir: String?, ballotId : String): String {
         val id = ballotId.replace(" ", "_")
         return "${decryptedBallotDir(ballotOverrideDir)}/$DECRYPTED_BALLOT_PREFIX$id$JSON_SUFFIX"

--- a/src/test/kotlin/org/cryptobiotic/eg/cli/RunExampleEncryptionTest.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/cli/RunExampleEncryptionTest.kt
@@ -26,9 +26,8 @@ class RunExampleEncryptionTest {
                 )
             )
 
-        val count1 = verifyOutput(inputDir, "$outputDir/encrypted_ballots/device11", true)
-        val count2 = verifyOutput(inputDir, "$outputDir/encrypted_ballots/device42", true)
-        assertEquals(nballots, count1 + count2)
+        val count = verifyOutput(inputDir, "$outputDir", true)
+        assertEquals(nballots, count)
     }
 
     @Test
@@ -50,9 +49,8 @@ class RunExampleEncryptionTest {
             )
         )
 
-        val count1 = verifyOutput(inputDir, "$outputDir/encrypted_ballots/device11", false)
-        val count2 = verifyOutput(inputDir, "$outputDir/encrypted_ballots/device42", false)
-        assertEquals(nballots, count1 + count2)
+        val count = verifyOutput(inputDir, "$outputDir", false)
+        assertEquals(nballots, count)
     }
 
 }

--- a/src/test/kotlin/org/cryptobiotic/eg/publish/ConsumerJsonTest.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/publish/ConsumerJsonTest.kt
@@ -73,7 +73,6 @@ class ConsumerJsonTest {
         }
     }
 
-    // TODO how come this doesnt barf on ballot_chain.json ??
     @Test
     fun iterateEncryptedBallotsSkipChain() {
         val topdir = "src/test/data/encrypt/testBallotChain"
@@ -81,7 +80,7 @@ class ConsumerJsonTest {
         val consumerIn = makeConsumer(topdir)
         val electionId = readElectionRecord(consumerIn).extendedBaseHash()
         var count = 0
-        for (ballot in consumerIn.iterateEncryptedBallotsFromDir("$topdir/encrypted_ballots/device1", null)) {
+        for (ballot in consumerIn.iterateAllEncryptedBallots(null)) {
             assertEquals(ballot.electionId, electionId)
             count++
         }

--- a/src/test/kotlin/org/cryptobiotic/eg/verifier/VerifierTest.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/verifier/VerifierTest.kt
@@ -25,12 +25,14 @@ class VerifierTest {
     }
 
     @Test
-    fun verificationAllJson() {
+    fun verificationEc() {
         RunVerifier.runVerifier("src/test/data/workflow/allAvailableEc", 11, true)
+        RunVerifier.runVerifier("src/test/data/workflow/someAvailableEc", 11, true)
     }
 
     @Test
-    fun verificationSomeJson() {
+    fun verificationInteger() {
+        RunVerifier.runVerifier("src/test/data/workflow/allAvailable", 11, true)
         RunVerifier.runVerifier("src/test/data/workflow/someAvailable", 11, true)
     }
 


### PR DESCRIPTION
Consumer.readEncryptedBallot() takes device name, not ballotDir. 
Add Verifier.verifyParameters()
Fix VerifyEncryptedBallots.assembleAndVerifyChains(), add test.