### PR TITLE
ElementModP/Q cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![License](https://img.shields.io/github/license/JohnLCaron/egk-ec)](https://github.com/JohnLCaron/egk-ec/blob/main/LICENSE.txt)
 ![GitHub branch checks state](https://img.shields.io/github/actions/workflow/status/JohnLCaron/egk-ec/unit-tests.yml)
-![Coverage](https://img.shields.io/badge/coverage-90.7%25%20LOC%20(6931/7639)-blue)
+![Coverage](https://img.shields.io/badge/coverage-90.8%25%20LOC%20(6930/7630)-blue)
 
 # ElectionGuard-Kotlin Elliptic Curve
 
-_last update 04/17/2024_
+_last update 04/24/2024_
 
 EGK Elliptic Curve (egk-ec) is an experimental implementation of [ElectionGuard](https://github.com/microsoft/electionguard), 
 [version 2.0](https://github.com/microsoft/electionguard/releases/download/v2.0/EG_Spec_2_0.pdf), 

--- a/src/main/kotlin/org/cryptobiotic/eg/core/ChaumPedersen.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/core/ChaumPedersen.kt
@@ -142,8 +142,8 @@ fun ChaumPedersenRangeProofKnownNonce.verify(
 
     val (alpha, beta) = ciphertext
     results.add(
-        if (alpha.isValidResidue() && beta.isValidResidue()) Ok(true) else
-            Err("    5.A,6.A values not in Zp^r: alpha = ${alpha.inBounds()} beta = ${beta.inBounds()}")
+        if (alpha.isValidElement() && beta.isValidElement()) Ok(true) else
+            Err("    5.A,6.A values not in Zp^r: alpha = ${alpha.isValidElement()} beta = ${beta.isValidElement()}")
     )
 
     val expandedProofs = proofs.mapIndexed { j, proof ->

--- a/src/main/kotlin/org/cryptobiotic/eg/core/Schnorr.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/core/Schnorr.kt
@@ -16,7 +16,7 @@ data class SchnorrProof(
 
     init {
         compatibleContextOrFail(publicCommitment, challenge, response)
-        require(publicCommitment.isValidResidue()) // 2.A
+        require(publicCommitment.isValidElement()) // 2.A
     }
 
     // verification Box 2, p 23
@@ -30,7 +30,7 @@ data class SchnorrProof(
         // c wouldnt agree unless h = g^u
         // therefore, whoever generated v knows s
 
-        val inBoundsK = publicCommitment.isValidResidue() // 2.A
+        val inBoundsK = publicCommitment.isValidElement() // 2.A
         val inBoundsU = response.inBounds() // 2.B
         val validChallenge = c == challenge // 2.C
         val success = inBoundsK && inBoundsU && validChallenge

--- a/src/main/kotlin/org/cryptobiotic/eg/core/UInt256.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/core/UInt256.kt
@@ -84,7 +84,7 @@ fun ByteArray.normalize(nbytes: Int): ByteArray {
  * beginning by computing "mod q".
  */
 fun UInt256.toElementModQ(context: GroupContext): ElementModQ =
-    context.binaryToElementModQsafe(bytes)
+    context.binaryToElementModQ(bytes)
 
 fun ElementModQ.toUInt256safe(): UInt256 = this.byteArray().toUInt256safe()
 fun ULong.toUInt256(): UInt256 = this.toByteArray().toUInt256safe()

--- a/src/main/kotlin/org/cryptobiotic/eg/core/ecgroup/EcElementModP.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/core/ecgroup/EcElementModP.kt
@@ -23,11 +23,8 @@ class EcElementModP(val group: EcGroupContext, val ec: VecElementP): ElementModP
         return EcElementModP(group, ec.mul(inv))
     }
 
-    // TODO what does it mean to be in bounds ??
-    override fun inBounds(): Boolean = true
-
-    // TODO check this
-    override fun isValidResidue(): Boolean {
+    /** Validate that this element is a member of the elliptic curve Group.*/
+    override fun isValidElement(): Boolean {
         return group.vecGroup.isPointOnCurve(this.ec.x, this.ec.y)
     }
 

--- a/src/main/kotlin/org/cryptobiotic/eg/core/ecgroup/VecGroup.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/core/ecgroup/VecGroup.kt
@@ -94,6 +94,8 @@ open class VecGroup(
     fun elementFromByteArray(ba: ByteArray): VecElementP? = elementFromByteArray1(ba)
 
     val ffbyte: Byte = (-1).toByte()
+
+    // this is for serialization of both the x and y value.
     fun elementFromByteArray2(ba: ByteArray): VecElementP? {
         if (ba.size != 2*pbyteLength) return null
         val allff = ba.fold( true) { a, b -> a && (b == ffbyte) }
@@ -123,6 +125,7 @@ open class VecGroup(
         return makeVecModP(x, y)
     }
 
+    // this is for testing that 1 and 2 are equivilent
     fun elementFromByteArray1from2(ba: ByteArray): VecElementP? {
         if (ba.size != 2*pbyteLength) return null
         val allff = ba.fold( true) { a, b -> a && (b == ffbyte) }
@@ -132,6 +135,7 @@ open class VecGroup(
         return makeVecModP(x, y)
     }
 
+    // this value will always > 1, since 0, 1 are not on the curve.
     fun randomElement(): VecElementP {
         for (j in 0 until 1000) { // limited in case theres a bug
             try {

--- a/src/main/kotlin/org/cryptobiotic/eg/decrypt/DecryptingTrustee.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/decrypt/DecryptingTrustee.kt
@@ -45,7 +45,7 @@ data class DecryptingTrustee(
         val results: MutableList<PartialDecryption> = mutableListOf()
         val badTexts = mutableListOf<Int>()
         texts.forEachIndexed { idx, text ->
-            if (!text.isValidResidue()) {
+            if (!text.isValidElement()) {
                 badTexts.add(idx)
             } else { // do not process if not valid
                 val u = nonces.get(idx) // random value u in Zq

--- a/src/main/kotlin/org/cryptobiotic/eg/verifier/Verifier.kt
+++ b/src/main/kotlin/org/cryptobiotic/eg/verifier/Verifier.kt
@@ -180,15 +180,15 @@ class Verifier(val record: ElectionRecord, val nthreads: Int = 11) {
     }
 
     // Verification 3 (Election public-key validation)
-    //An election verifier must verify the correct computation of the joint election public key.
-    //(3.A) The value Ki is in Zpr and Ki  ̸= 1 mod p
+    // An election verifier must verify the correct computation of the joint election public key.
+    // (3.A) The value Ki is in Z_p^r and K_i  != 1 mod p
     private fun verifyElectionPublicKey(): Result<Boolean, String> {
         val errors = mutableListOf<Result<Boolean, String>>()
 
         val guardiansSorted = this.record.guardians().sortedBy { it.xCoordinate }
         guardiansSorted.forEach {
             val Ki = it.publicKey()
-            if (!Ki.isValidResidue()) {
+            if (!Ki.isValidElement()) {
                 errors.add(Err("  3.A publicKey Ki (${it.guardianId} is not in Zp^r"))
             }
             if (Ki == group.ONE_MOD_P) {

--- a/src/test/kotlin/org/cryptobiotic/eg/core/GroupTest.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/core/GroupTest.kt
@@ -6,7 +6,6 @@ import io.kotest.property.checkAll
 import io.kotest.property.forAll
 import org.cryptobiotic.eg.core.ecgroup.EcGroupContext
 import org.cryptobiotic.eg.core.intgroup.tinyGroup
-import org.cryptobiotic.util.Stopwatch
 import kotlin.test.*
 
 class GroupTest {
@@ -53,14 +52,21 @@ class GroupTest {
     }
 
     @Test
-    fun generatorsWork() {
-        groups.forEach { generatorsWork(it) }
+    fun qInBounds() {
+        groups.forEach { qInBounds(it) }
     }
 
-    fun generatorsWork(context: GroupContext) {
+    fun qInBounds(context: GroupContext) {
         runTest {
-            forAll(propTestFastConfig, elementsModP(context)) { it.inBounds() }
             forAll(propTestFastConfig, elementsModQ(context)) { it.inBounds() }
+        }
+    }
+
+    @Test
+    fun pIsResidue() {
+        val group = EcGroupContext("P-256")
+        runTest {
+            forAll(propTestFastConfig, elementsModP(group)) { it.isValidElement() }
         }
     }
 
@@ -71,7 +77,7 @@ class GroupTest {
 
     fun validResiduesForGPowP(context: GroupContext) {
         runTest {
-            forAll(propTestFastConfig, validResiduesOfP(context)) { it.isValidResidue() }
+            forAll(propTestFastConfig, validResiduesOfP(context)) { it.isValidElement() }
         }
     }
 
@@ -137,9 +143,9 @@ class GroupTest {
         runTest {
             checkAll(
                 propTestFastConfig,
-                elementsModPNoZero(context),
-                elementsModPNoZero(context),
-                elementsModPNoZero(context)
+                elementsModP(context),
+                elementsModP(context),
+                elementsModP(context)
             ) { a, b, c ->
                 assertEquals(a, a * context.ONE_MOD_P) // identity
                 assertEquals(a * b, b * a) // commutative

--- a/src/test/kotlin/org/cryptobiotic/eg/core/KotestGenerators.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/core/KotestGenerators.kt
@@ -6,23 +6,27 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.property.Arb
 import io.kotest.property.PropTestConfig
 import io.kotest.property.ShrinkingMode
-import io.kotest.property.arbitrary.byte
-import io.kotest.property.arbitrary.byteArray
-import io.kotest.property.arbitrary.constant
-import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.*
 
-/** Generate an arbitrary ElementModP in [minimum, P) for the given group context. */
-fun elementsModP(ctx: GroupContext, minimum: Int = 0): Arb<ElementModP> =
-    Arb.byteArray(Arb.constant(ctx.MAX_BYTES_P), Arb.byte())
-        .map { ctx.randomElementModP() }
+/** Generate an arbitrary ElementModP for the given group context. */
+fun elementsModP(ctx: GroupContext): Arb<ElementModP> {
+    return arbitrary { ctx.randomElementModP() }
+}
+
+//    Arb.byteArray(Arb.constant(ctx.MAX_BYTES_P), Arb.byte())
+//        .map { _ -> ctx.randomElementModP() }
 
 /** Generate an arbitrary ElementModP in [1, P) for the given group context. */
-fun elementsModPNoZero(ctx: GroupContext) = elementsModP(ctx, 1)
+// fun elementsModPNoZero(ctx: GroupContext) = elementsModP(ctx)
 
 /** Generate an arbitrary ElementModQ in [minimum, Q) for the given group context. */
-fun elementsModQ(ctx: GroupContext, minimum: Int = 0): Arb<ElementModQ> =
+fun elementsModQ(ctx: GroupContext, minimum: Int = 0): Arb<ElementModQ> = arbitrary{ ctx.randomElementModQ() }
+
+/* fun elementsModQ(ctx: GroupContext, minimum: Int = 0): Arb<ElementModQ> =
     Arb.byteArray(Arb.constant(ctx.MAX_BYTES_Q), Arb.byte())
         .map { ctx.randomElementModQ() }
+
+ */
 
 /** Generate an arbitrary ElementModQ in [1, Q) for the given group context. */
 fun elementsModQNoZero(ctx: GroupContext) = elementsModQ(ctx, 1)

--- a/src/test/kotlin/org/cryptobiotic/eg/core/SchnorrTest.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/core/SchnorrTest.kt
@@ -28,9 +28,8 @@ private fun testSchnorrProof(name: String, group: GroupContext) = wordSpec {
                     Arb.int(1, 11),
                     Arb.int(0, 10),
                     elementsModQ(group),
-                    validResiduesOfP(group),
                     elementsModQ(group)
-                ) { kp, i, j, nonce, fakeElementModP, fakeElementModQ ->
+                ) { kp, i, j, nonce, fakeElementModQ ->
                     val goodProof = kp.schnorrProof(i, j, nonce)
                     (goodProof.validate(i, j) is Ok) shouldBe true
                 }
@@ -47,9 +46,8 @@ private fun testSchnorrProof(name: String, group: GroupContext) = wordSpec {
                     Arb.int(1, 11),
                     Arb.int(0, 10),
                     elementsModQ(group),
-                    validResiduesOfP(group),
                     elementsModQ(group)
-                ) { kp, i, j, nonce, fakeElementModP, fakeElementModQ ->
+                ) { kp, i, j, nonce, fakeElementModQ ->
                     val goodProof = kp.schnorrProof(i, j, nonce)
                     val badProof1 = goodProof.copy(challenge = fakeElementModQ)
                     val badProof2 = goodProof.copy(response = fakeElementModQ)

--- a/src/test/kotlin/org/cryptobiotic/eg/core/TestSetMembership.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/core/TestSetMembership.kt
@@ -39,7 +39,7 @@ class TestSetMembership {
     }
 
     fun checkMembership(x: ElementModP?): Boolean {
-        return (x != null) && x.isValidResidue()
+        return (x != null) && x.isValidElement()
     }
 
 }

--- a/src/test/kotlin/org/cryptobiotic/eg/core/ecgroup/TestAgainstNative.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/core/ecgroup/TestAgainstNative.kt
@@ -18,7 +18,7 @@ class TestAgainstNative {
 
             // randomElementModP seems to always be the case when p = 3 mod 4
             repeat(100) {
-                val elemP = group.randomElementModP(2).ec
+                val elemP = group.randomElementModP().ec
                 val elemPy2 = vecGroupN.equationf(elemP.x)
 
                 val elemPy = vecGroup.sqrt(elemPy2)
@@ -42,7 +42,7 @@ class TestAgainstNative {
 
         // seems to be the case when p = 3 mod 4
         repeat(100) {
-            val elemP = group.randomElementModP(2).ec
+            val elemP = group.randomElementModP().ec
             val elemPy = elemP.y
 
             val sqrtPy = vecGroup.sqrt(elemPy)

--- a/src/test/kotlin/org/cryptobiotic/eg/core/ecgroup/TestElem.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/core/ecgroup/TestElem.kt
@@ -7,6 +7,7 @@ import org.cryptobiotic.util.Stopwatch
 import java.math.BigInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class TestElem {
 
@@ -113,13 +114,35 @@ class TestElem {
     }
 
     @Test
+    fun testZeroOnCurve() {
+        val ecGroup = VecGroups.getEcGroup("P-256")
+        val fx = BigInteger.ZERO
+        val fy = ecGroup.equationf(fx)
+        // is this legal ?
+        assertFailsWith<RuntimeException> {
+            VecElementP(ecGroup, fx, fy)
+        }
+    }
+
+    @Test
+    fun testOneOnCurve() {
+        val ecGroup = VecGroups.getEcGroup("P-256")
+        val fx = BigInteger.ONE
+        val fy = ecGroup.equationf(fx)
+        // is this legal ?
+        assertFailsWith<RuntimeException> {
+            VecElementP(ecGroup, fx, fy)
+        }
+    }
+
+    @Test
     fun testSqrt() {
         if (VecGroups.hasNativeLibrary()) {
             val group = productionGroup("P-256") as EcGroupContext
             val vecGroupN = group.vecGroup as VecGroupNative
 
             repeat(100) {
-                val elemP = group.randomElementModP(2).ec
+                val elemP = group.randomElementModP().ec
                 val elemPx = elemP.x
                 val elemPy2 = vecGroupN.equationf(elemPx)
 

--- a/src/test/kotlin/org/cryptobiotic/eg/publish/json/WebappDecryptionTest.kt
+++ b/src/test/kotlin/org/cryptobiotic/eg/publish/json/WebappDecryptionTest.kt
@@ -60,9 +60,9 @@ class WebappDecryptionTest {
             ) {  name, nrequests ->
                 val drequest =
                     DecryptRequest(
-                        listOf( elementsModP(group, minimum = 2).single(),
-                        elementsModP(group, minimum = 2).single(),
-                        elementsModP(group, minimum = 2).single())
+                        listOf( elementsModP(group).single(),
+                        elementsModP(group).single(),
+                        elementsModP(group).single())
                     )
                 val drequestj = drequest.publishJson()
                 val roundtrip = drequestj.import(group)
@@ -86,9 +86,9 @@ class WebappDecryptionTest {
             ) {  name, nrequests ->
                 val crs = List(nrequests) {
                     PartialDecryption(
-                        elementsModP(group, minimum = 2).single(),
-                        elementsModP(group, minimum = 2).single(),
-                        elementsModP(group, minimum = 2).single(),
+                        elementsModP(group).single(),
+                        elementsModP(group).single(),
+                        elementsModP(group).single(),
                     )
                 }
                 val org = PartialDecryptions(null, 42, crs)


### PR DESCRIPTION
Rename ElementModP.isValidResidue() to isValidElement().
Element.inBounds() only applies to ElementModQ.
Remove group.isProductionStrength()
Remove binaryToElementModP(Q)safe, used only by randomElementModP(Q)